### PR TITLE
Update all uses of `uname -p` to `uname -m`

### DIFF
--- a/JavaGUI/jni/makefile
+++ b/JavaGUI/jni/makefile
@@ -67,14 +67,14 @@ else
 
 	ifndef $(ARCHNAME)
 
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 

--- a/JavaGUI/makefile
+++ b/JavaGUI/makefile
@@ -46,14 +46,14 @@ else
 
 	ifndef $(ARCHNAME)
 
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 

--- a/TSDRPlugin_ExtIO/makefile
+++ b/TSDRPlugin_ExtIO/makefile
@@ -56,14 +56,14 @@ else
 	
 	ifndef $(ARCHNAME)
 	
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 	

--- a/TSDRPlugin_Mirics/makefile
+++ b/TSDRPlugin_Mirics/makefile
@@ -59,14 +59,14 @@ else
 	
 	ifndef $(ARCHNAME)
 	
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 	

--- a/TSDRPlugin_RawFile/makefile
+++ b/TSDRPlugin_RawFile/makefile
@@ -66,14 +66,14 @@ else
 	
 	ifndef $(ARCHNAME)
 	
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 	

--- a/TSDRPlugin_UHD/makefile
+++ b/TSDRPlugin_UHD/makefile
@@ -70,14 +70,14 @@ else
 
 	ifndef $(ARCHNAME)
 
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 

--- a/TempestSDR/makefile
+++ b/TempestSDR/makefile
@@ -62,14 +62,14 @@ else
 
 	ifndef $(ARCHNAME)
 
-		UNAME_P := $(shell uname -p)
-		ifeq ($(UNAME_P),x86_64)
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
 			ARCHNAME = X64
 		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
+		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
 		endif
-		ifneq ($(filter arm%,$(UNAME_P)),)
+		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM
 		endif
 


### PR DESCRIPTION
`uname -p` outputs the string 'unknown' un some platforms and is marked non-portable.

I had to make this change for the plugins to be placed in the proper folder on my system.