### PR TITLE
fix: darwin builds where homebrew is installed on different paths

### DIFF
--- a/TSDRPlugin_SdrPlay/makefile
+++ b/TSDRPlugin_SdrPlay/makefile
@@ -45,7 +45,8 @@ ifeq ($(OS),Windows_NT)
 	endif
 else ifeq ($(shell uname -s),Darwin)
 	OSNAME ?= MAC
-	INC += /opt/local/include
+	HOMEBREW_HOME ?= /opt/local
+	INC += ${HOMEBREW_HOME}/include
 	ifeq ($(shell uname -m),x86)
 		ARCHNAME = X86
 	endif

--- a/TSDRPlugin_UHD/makefile
+++ b/TSDRPlugin_UHD/makefile
@@ -51,7 +51,8 @@ ifeq ($(OS),Windows_NT)
 else ifeq ($(shell uname -s),Darwin)
 	OSNAME ?= MAC
 	EXT ?= .so
-	INC += /opt/local/include
+	HOMEBREW_HOME ?= /opt/local
+	INC += ${HOMEBREW_HOME}/include
 	ifeq ($(shell uname -m),x86)
 		ARCHNAME = X86
 	endif


### PR DESCRIPTION
Homebrew can be installed on different paths.

Changed the makefile so it attempts to use the `HOMEBREW_HOME` as the libs folder for all the c++ include files