### PR TITLE
Add arm64 support

### DIFF
--- a/JavaGUI/jni/makefile
+++ b/JavaGUI/jni/makefile
@@ -54,6 +54,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -73,6 +76,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM

--- a/JavaGUI/makefile
+++ b/JavaGUI/makefile
@@ -33,6 +33,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -82,7 +85,7 @@ endif
 # in the parent directory with the exact same name as the plugin names. The library files
 # produced need to have the name of the plugin folder and need to be in the bin directory.
 # The default plugin file will make sure this is compatible.
-PLUGINS=TSDRPlugin_RawFile 
+PLUGINS=TSDRPlugin_RawFile
 
 ifeq ($(OSNAME),WINDOWS)
 # Windows only plugins
@@ -90,7 +93,10 @@ PLUGINS += TSDRPlugin_SDRPlay TSDRPlugin_ExtIO
 else ifeq ($(OSNAME), LINUX)
 PLUGINS += TSDRPlugin_UHD
 else ifeq ($(OSNAME), MAC)
+ifeq ($(ARCHNAME), ARM64)
+else
 PLUGINS += TSDRPlugin_UHD TSDRPlugin_SDRPlay
+endif
 endif
 
 # USER CONFIGURATION ENDS HERE

--- a/JavaGUI/src/martin/tempest/core/TSDRLibrary.java
+++ b/JavaGUI/src/martin/tempest/core/TSDRLibrary.java
@@ -111,7 +111,9 @@ public class TSDRLibrary {
 		else if (rawOSNAME.contains("mac"))
 			OSNAME = "MAC";
 
-		if (rawARCHNAME.contains("arm"))
+		if (rawARCHNAME.contains("aarch64") || (rawARCHNAME.contains("arm") && rawARCHNAME.contains("64")))
+			ARCHNAME = "ARM64";
+		else if (rawARCHNAME.contains("arm"))
 			ARCHNAME = "ARM";
 		else if (rawARCHNAME.contains("64"))
 			ARCHNAME = "X64";

--- a/TSDRPlugin_RawFile/makefile
+++ b/TSDRPlugin_RawFile/makefile
@@ -53,6 +53,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -72,6 +75,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM

--- a/TempestSDR/makefile
+++ b/TempestSDR/makefile
@@ -49,6 +49,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -68,6 +71,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM


### PR DESCRIPTION
Added arm64 detection during compilation.

Changed default behaviour on MacOS – on MAC/ARM64 skips SDRPlay and UHD plugins since they're not compatible.

Tested on ARM-based MacOS and RaspberryPi5.