### PR TITLE
Feature/tsdr plugin librtlsdr

### DIFF
--- a/JavaGUI/jni/makefile
+++ b/JavaGUI/jni/makefile
@@ -54,6 +54,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -73,6 +76,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM

--- a/JavaGUI/makefile
+++ b/JavaGUI/makefile
@@ -33,6 +33,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -82,7 +85,7 @@ endif
 # in the parent directory with the exact same name as the plugin names. The library files
 # produced need to have the name of the plugin folder and need to be in the bin directory.
 # The default plugin file will make sure this is compatible.
-PLUGINS=TSDRPlugin_RawFile 
+PLUGINS=TSDRPlugin_RawFile
 
 ifeq ($(OSNAME),WINDOWS)
 # Windows only plugins
@@ -90,7 +93,10 @@ PLUGINS += TSDRPlugin_SDRPlay TSDRPlugin_ExtIO
 else ifeq ($(OSNAME), LINUX)
 PLUGINS += TSDRPlugin_UHD
 else ifeq ($(OSNAME), MAC)
+ifeq ($(ARCHNAME), ARM64)
+else
 PLUGINS += TSDRPlugin_UHD TSDRPlugin_SDRPlay
+endif
 endif
 
 # USER CONFIGURATION ENDS HERE

--- a/JavaGUI/makefile
+++ b/JavaGUI/makefile
@@ -87,15 +87,27 @@ endif
 # The default plugin file will make sure this is compatible.
 PLUGINS=TSDRPlugin_RawFile
 
+# User-configurable switch for RTL-SDR plugin (must match main makefile)
+BUILD_RTL_SDR ?= 1
+
 ifeq ($(OSNAME),WINDOWS)
 # Windows only plugins
 PLUGINS += TSDRPlugin_SDRPlay TSDRPlugin_ExtIO
 else ifeq ($(OSNAME), LINUX)
 PLUGINS += TSDRPlugin_UHD
+ifeq ($(BUILD_RTL_SDR),1)
+PLUGINS += TSDRPlugin_RTL
+endif
 else ifeq ($(OSNAME), MAC)
 ifeq ($(ARCHNAME), ARM64)
+ifeq ($(BUILD_RTL_SDR),1)
+PLUGINS += TSDRPlugin_RTL
+endif
 else
 PLUGINS += TSDRPlugin_UHD TSDRPlugin_SDRPlay
+ifeq ($(BUILD_RTL_SDR),1)
+PLUGINS += TSDRPlugin_RTL
+endif
 endif
 endif
 

--- a/JavaGUI/src/martin/tempest/core/TSDRLibrary.java
+++ b/JavaGUI/src/martin/tempest/core/TSDRLibrary.java
@@ -111,7 +111,9 @@ public class TSDRLibrary {
 		else if (rawOSNAME.contains("mac"))
 			OSNAME = "MAC";
 
-		if (rawARCHNAME.contains("arm"))
+		if (rawARCHNAME.contains("aarch64") || (rawARCHNAME.contains("arm") && rawARCHNAME.contains("64")))
+			ARCHNAME = "ARM64";
+		else if (rawARCHNAME.contains("arm"))
 			ARCHNAME = "ARM";
 		else if (rawARCHNAME.contains("64"))
 			ARCHNAME = "X64";

--- a/JavaGUI/src/martin/tempest/sources/TSDRRTLSource.java
+++ b/JavaGUI/src/martin/tempest/sources/TSDRRTLSource.java
@@ -1,0 +1,22 @@
+/*
+# SPDX-License-Identifier: GPL-3.0-or-later
+# TempestSDR Plugin Architecture:
+#  Copyright (c) 2014 Martin Marinov.
+# librtlsdr library:
+#  Copyright (C) 2012-2013 by Steve Markgraf <steve@steve-m.de>
+#  Copyright (C) 2012 by Dimitri Stolnikov <horiz0n@gmx.net>
+# Plugin implementation:
+#  Copyright (C) 2025 Tymoteusz Vogt
+*/
+package martin.tempest.sources;
+
+/**
+ * This plugin allows for RTL2832U based SDR USB dongles to be used with the application.
+ */
+public class TSDRRTLSource extends TSDRSource {
+
+	public TSDRRTLSource() {
+		super("RTL2832U SDR dongle", "TSDRPlugin_RTL", false);
+	}
+
+}

--- a/JavaGUI/src/martin/tempest/sources/TSDRSource.java
+++ b/JavaGUI/src/martin/tempest/sources/TSDRSource.java
@@ -41,6 +41,7 @@ public class TSDRSource {
 		new TSDRUHDSource(),
 		new TSDRExtIOSource(),
 		new TSDRSDRPlaySource(),
+		new TSDRRTLSource(),
 	};
 	
 	/** The native name of the dynamic library. It should not contain prefixes or extensions.

--- a/TSDRPlugin_RTL/README
+++ b/TSDRPlugin_RTL/README
@@ -1,0 +1,12 @@
+This plugin enables straightforward use of RTL-SDR USB dongles (RTL2832U) as a live signal source. It uses generic librtlsdr library version, can also be compiled using tweaked RTLSDR version, but by default should work with all RTL2832U devices that are supported by librtlsdr.
+
+#### macOS via Homebrew
+```bash
+brew install librtlsdr
+```
+
+#### Linux (Debian/Ubuntu based, including e.g. Raspberry Pi OS)
+```bash
+sudo apt-get install librtlsdr-dev
+```
+

--- a/TSDRPlugin_RTL/makefile
+++ b/TSDRPlugin_RTL/makefile
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# TempestSDR Plugin Architecture:
+#  Copyright (c) 2014 Martin Marinov.
+# librtlsdr library:
+#  Copyright (C) 2012-2013 by Steve Markgraf <steve@steve-m.de>
+#  Copyright (C) 2012 by Dimitri Stolnikov <horiz0n@gmx.net>
+# Plugin contribution:
+#  Copyright (C) 2025 Tymoteusz Vogt
+
+PLUGNAME=TSDRPlugin_RTL
+
+OBJS=$(PLUGNAME).o
+DEPS=TSDRPlugin.h TSDRCodes.h
+
+LIBS+=-lrtlsdr
+
+INC+=-I/usr/local/include
+
+ifeq ($(BUILD_TYPE),Debug)
+	DEBUGFLAGS+=-g -O0
+else
+	CFLAGS+=-O3
+endif
+
+# END OF CONFIGURATION
+
+# TSDRPlugin.h location
+HEADLOCATION=../TempestSDR/src/include/
+
+# Discover the library extension for each OS
+# NOTE: Windows is not supported – use ExtIO plugin instead.
+ifeq ($(shell uname -s),Darwin)
+	OSNAME ?= MAC
+	EXT ?= .so
+	HOMEBREW_PREFIX ?= $(shell brew --prefix 2>/dev/null || echo /opt/homebrew)
+	INC += -I$(HOMEBREW_PREFIX)/include
+	LIBS += -L$(HOMEBREW_PREFIX)/lib
+	ifndef ARCHNAME
+		ifeq ($(shell uname -m),x86)
+			ARCHNAME = X86
+		endif
+		ifeq ($(shell uname -m),x86_64)
+			ARCHNAME = X64
+		endif
+		ifeq ($(shell uname -m),arm64)
+			ARCHNAME = ARM64
+		endif
+	endif
+else
+
+	ifndef OSNAME
+
+		UNAME_S := $(shell uname -s)
+		ifeq ($(UNAME_S),Linux)
+			OSNAME = LINUX
+		endif
+
+	endif
+
+	ifndef ARCHNAME
+
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),x86_64)
+			ARCHNAME = X64
+		endif
+		ifneq ($(filter %86,$(UNAME_M)),)
+			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
+		endif
+		ifneq ($(filter arm%,$(UNAME_M)),)
+			ARCHNAME = ARM
+		endif
+
+	endif
+endif
+
+ifeq ($(OSNAME),LINUX)
+	EXT=.so
+	LIBPREFIX=lib
+	CFLAGS+=-fPIC
+endif
+
+ifeq ($(OSNAME),MAC)
+	EXT=.so
+	LIBPREFIX=
+	CFLAGS+=-fPIC
+endif
+
+# Output dir
+OUTDIR=bin/$(OSNAME)/$(ARCHNAME)/
+OUTSOURCE=$(OUTDIR)$(LIBPREFIX)$(PLUGNAME)$(EXT)
+
+CC?=gcc
+CFLAGS+=-Wall -Wextra $(INC) $(DEBUGFLAGS) -I./src
+
+all: before_build actual_build after_build
+
+before_build:
+	@echo "Building $(PLUGNAME) for $(OSNAME)/$(ARCHNAME)..."
+	@mkdir -p $(OUTDIR)
+	@mkdir -p obj
+	@cp $(HEADLOCATION)TSDRPlugin.h ./src/
+	@cp $(HEADLOCATION)TSDRCodes.h ./src/
+
+actual_build: $(OBJS)
+	$(CC) -shared -o $(OUTSOURCE) obj/*.o $(LIBS)
+	@echo "Built $(OUTSOURCE)"
+
+%.o: src/%.c
+	$(CC) -c -o obj/$@ $< $(CFLAGS)
+
+after_build:
+	@echo "Build complete!"
+
+clean:
+	rm -f obj/*.o src/TSDRPlugin.h src/TSDRCodes.h $(OUTSOURCE)
+
+install:
+	@echo "Installing to ../Release/dlls/$(OSNAME)/$(ARCHNAME)/"
+	@mkdir -p ../Release/dlls/$(OSNAME)/$(ARCHNAME)/
+	@cp $(OUTSOURCE) ../Release/dlls/$(OSNAME)/$(ARCHNAME)/
+	@echo "Install complete!".PHONY: all before_build actual_build after_build clean install

--- a/TSDRPlugin_RTL/src/TSDRPlugin_RTL.c
+++ b/TSDRPlugin_RTL/src/TSDRPlugin_RTL.c
@@ -1,0 +1,303 @@
+/*
+# SPDX-License-Identifier: GPL-3.0-or-later
+# TempestSDR Plugin Architecture:
+#  Copyright (c) 2014 Martin Marinov.
+# librtlsdr library:
+#  Copyright (C) 2012-2013 by Steve Markgraf <steve@steve-m.de>
+#  Copyright (C) 2012 by Dimitri Stolnikov <horiz0n@gmx.net>
+# Plugin contribution:
+#  Copyright (C) 2025 by Tymoteusz Vogt
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <rtl-sdr.h>
+
+#include "TSDRPlugin.h"
+#include "TSDRCodes.h"
+
+// Global device state
+static rtlsdr_dev_t *dev = NULL;
+static volatile int is_running = 0;
+static uint32_t current_samplerate = 2400000; // 2.4 MHz default
+static uint32_t current_frequency = 100000000; // 100 MHz default
+static float current_gain = 0.5f;
+static int ppm_error = 0;
+
+// Callback data
+static tsdrplugin_readasync_function user_callback = NULL;
+static void *user_ctx = NULL;
+static float *conversion_buffer = NULL;
+static size_t conversion_buffer_size = 0;
+
+// Error handling
+static int errormsg_code = TSDR_OK;
+static char *errormsg = NULL;
+static int errormsg_size = 0;
+
+#define RETURN_EXCEPTION(message, status) {announceexception(message, status); return status;}
+#define RETURN_OK() {errormsg_code = TSDR_OK; return TSDR_OK;}
+
+static inline void announceexception(const char *message, int status) {
+    errormsg_code = status;
+    if (status == TSDR_OK) return;
+
+    const int length = strlen(message);
+    if (errormsg_size == 0) {
+        errormsg_size = length;
+        errormsg = (char *)malloc(length + 1);
+    } else if (length > errormsg_size) {
+        errormsg_size = length;
+        errormsg = (char *)realloc((void *)errormsg, length + 1);
+    }
+    strcpy(errormsg, message);
+}
+
+static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
+    (void)ctx; // unused
+    
+    if (!is_running || user_callback == NULL) return;
+    
+    uint32_t samples = len; 
+    
+    if (conversion_buffer_size < samples) {
+        conversion_buffer = (float *)realloc(conversion_buffer, samples * sizeof(float));
+        conversion_buffer_size = samples;
+    }
+    
+    for (uint32_t i = 0; i < samples; i++) {
+        conversion_buffer[i] = (buf[i] - 127.5f) / 127.5f;
+    }
+    
+    user_callback(conversion_buffer, samples, user_ctx, 0);
+}
+
+// Plugin API architecture implementation
+
+void TSDRPLUGIN_API __stdcall tsdrplugin_getName(char *name) {
+    strcpy(name, "TSDR RTL-SDR Plugin");
+}
+
+int TSDRPLUGIN_API __stdcall tsdrplugin_init(const char *params) {
+    uint32_t device_count = rtlsdr_get_device_count();
+    if (device_count == 0) {
+        RETURN_EXCEPTION("No rtl sdr device found, make sure other application isn't using it, drivers are installed and device is plugged in.", TSDR_CANNOT_OPEN_DEVICE);
+    }
+    
+    // Parse parameters: [device_index] [sample_rate] [ppm_error]
+    // All parameters are optional
+    // Defaults: device 0 (first available), 2.4 MHz sample rate (max stable), 0 ppm correction
+    uint32_t device_index = 0;
+    uint32_t requested_samplerate = current_samplerate;
+    ppm_error = 0;
+    
+    if (params && strlen(params) > 0) {
+        int parsed = sscanf(params, "%u %u %d", &device_index, &requested_samplerate, &ppm_error);
+        
+        // Shown if user input parsing fails
+        if (parsed == 0) {
+            RETURN_EXCEPTION(
+                "Invalid parameters.\n\n"
+                "Usage: \"device_index sample_rate ppm_error\"\n"
+                "Parameters are positional and optional\n\n"
+                "Examples:\n"
+                "  (empty)           - First device, 2.4 MHz, 0 ppm\n"
+                "  \"1\"             - Second device, default settings\n"
+                "  \"0 2048000\"     - First device, 2.048 MHz sample rate\n"
+                "  \"0 2400000 15\"  - First device, 2.4 MHz, +15 ppm correction\n\n"
+                "Parameters:\n"
+                "  device_index:  0 to count of devices - 1, default: 0\n"
+                "  sample_rate:   225000 to 3200000 Hz, default: 2400000Hz (maximum stable rate)\n"
+                "  ppm_error:     -100 to +100 (frequency correction), default: 0",
+                TSDR_INVALID_PARAMETER
+            );
+        }
+    }
+    
+    if (device_index >= device_count) {
+        char errmsg[256];
+        snprintf(errmsg, sizeof(errmsg), 
+                 "Device index %u is out of range. Found %u devices. Therefore max index 0-%u.", 
+                 device_index, device_count, device_count - 1);
+        RETURN_EXCEPTION(errmsg, TSDR_INVALID_PARAMETER);
+    }
+    
+    // Validate sample rate range
+    // There should be a list of allowed values instead tho
+    if (requested_samplerate < 225000 || requested_samplerate > 3200000) {
+        char errmsg[256];
+        snprintf(errmsg, sizeof(errmsg),
+                 "Sample rate %u Hz out of device supported range. Valid range 225000 to 32000000 (usually max 2400000 stable)",
+                 requested_samplerate);
+        RETURN_EXCEPTION(errmsg, TSDR_INVALID_PARAMETER);
+    }
+    
+    // Initialize
+    int r = rtlsdr_open(&dev, device_index);
+    if (r < 0) {
+        char errmsg[256];
+        const char *device_name = rtlsdr_get_device_name(device_index);
+        snprintf(errmsg, sizeof(errmsg),
+                 "Failed to open rtl dongle #%u (%s). Error code: %d",
+                 device_index, device_name ? device_name : "unknown", r);
+        RETURN_EXCEPTION(errmsg, TSDR_CANNOT_OPEN_DEVICE);
+    }
+    
+    // Configure 
+    rtlsdr_set_sample_rate(dev, requested_samplerate);
+    current_samplerate = rtlsdr_get_sample_rate(dev); // Get actual rate
+    rtlsdr_set_center_freq(dev, current_frequency);
+    rtlsdr_set_freq_correction(dev, ppm_error);
+    
+    // Set gain control via java gui
+    rtlsdr_set_tuner_gain_mode(dev, 1);
+    
+    // Set initial gain
+    int gain_count = rtlsdr_get_tuner_gains(dev, NULL);
+    if (gain_count > 0) {
+        int *gains = (int *)malloc(sizeof(int) * gain_count);
+        rtlsdr_get_tuner_gains(dev, gains);
+        int gain_index = (int)(current_gain * (gain_count - 1));
+        if (gain_index < 0) gain_index = 0;
+        if (gain_index >= gain_count) gain_index = gain_count - 1;
+        rtlsdr_set_tuner_gain(dev, gains[gain_index]);
+        free(gains);
+    }
+    
+    RETURN_OK();
+}
+
+uint32_t TSDRPLUGIN_API __stdcall tsdrplugin_setsamplerate(uint32_t rate) {
+    if (is_running) {
+        return current_samplerate;
+    }
+    
+    if (dev == NULL) {
+        current_samplerate = rate;
+        return current_samplerate;
+    }
+    
+    // Clamp to valid range (225 kHz - 3.2 MHz)
+    if (rate < 225000) rate = 225000;
+    if (rate > 3200000) rate = 3200000;
+    
+    int r = rtlsdr_set_sample_rate(dev, rate);
+    if (r == 0) {
+        current_samplerate = rtlsdr_get_sample_rate(dev);
+    }
+    
+    return current_samplerate;
+}
+
+uint32_t TSDRPLUGIN_API __stdcall tsdrplugin_getsamplerate(void) {
+    if (dev != NULL) {
+        current_samplerate = rtlsdr_get_sample_rate(dev);
+    }
+    return current_samplerate;
+}
+
+int TSDRPLUGIN_API __stdcall tsdrplugin_setbasefreq(uint32_t freq) {
+    current_frequency = freq;
+    
+    if (dev != NULL) {
+        int r = rtlsdr_set_center_freq(dev, freq);
+        if (r < 0) {
+            RETURN_EXCEPTION("Failed to set frequency. Frequency may be out of range.", TSDR_INVALID_PARAMETER_VALUE);
+        }
+    }
+    
+    RETURN_OK();
+}
+
+int TSDRPLUGIN_API __stdcall tsdrplugin_setgain(float gain) {
+    if (gain < 0.0f) gain = 0.0f;
+    if (gain > 1.0f) gain = 1.0f;
+    current_gain = gain;
+    
+    if (dev != NULL) {
+        int gain_count = rtlsdr_get_tuner_gains(dev, NULL);
+        if (gain_count > 0) {
+            int *gains = (int *)malloc(sizeof(int) * gain_count);
+            rtlsdr_get_tuner_gains(dev, gains);
+            
+            int gain_index = (int)(gain * (gain_count - 1));
+            if (gain_index < 0) gain_index = 0;
+            if (gain_index >= gain_count) gain_index = gain_count - 1;
+            
+            rtlsdr_set_tuner_gain(dev, gains[gain_index]);
+            
+            free(gains);
+        }
+    }
+    
+    RETURN_OK();
+}
+
+int TSDRPLUGIN_API __stdcall tsdrplugin_stop(void) {
+    is_running = 0;
+    
+    if (dev != NULL) {
+        rtlsdr_cancel_async(dev);
+        usleep(100000); //100ms delay 
+    }
+    
+    RETURN_OK();
+}
+
+char * TSDRPLUGIN_API __stdcall tsdrplugin_getlasterrortext(void) {
+    if (errormsg_code == TSDR_OK)
+        return NULL;
+    return errormsg;
+}
+
+int TSDRPLUGIN_API __stdcall tsdrplugin_readasync(tsdrplugin_readasync_function cb, void *ctx) {
+    if (dev == NULL) {
+        RETURN_EXCEPTION("Device not initialized. Call tsdrplugin_init first.", TSDR_ERR_PLUGIN);
+    }
+    
+    user_callback = cb;
+    user_ctx = ctx;
+    is_running = 1;
+    
+    rtlsdr_reset_buffer(dev);
+    
+    int r = rtlsdr_read_async(dev, rtlsdr_callback, NULL, 0, 0);
+    
+    is_running = 0;
+    
+    if (r < 0 && r != -6) { // -6 is RTLSDR_ERR_CANCELED (normal stop)
+        RETURN_EXCEPTION("Async read failed. Device may have been disconnected.", TSDR_ERR_PLUGIN);
+    }
+    
+    RETURN_OK();
+}
+
+void TSDRPLUGIN_API __stdcall tsdrplugin_cleanup(void) {
+    is_running = 0;
+    
+    if (dev != NULL) {
+        rtlsdr_cancel_async(dev);
+        usleep(200000); //200ms delay
+    }
+    
+    if (conversion_buffer != NULL) {
+        free(conversion_buffer);
+        conversion_buffer = NULL;
+        conversion_buffer_size = 0;
+    }
+    
+    if (dev != NULL) {
+        rtlsdr_close(dev);
+        dev = NULL;
+    }
+    
+    if (errormsg != NULL) {
+        free(errormsg);
+        errormsg = NULL;
+        errormsg_size = 0;
+    }
+}

--- a/TSDRPlugin_RTL/src/TSDRPlugin_RTL.h
+++ b/TSDRPlugin_RTL/src/TSDRPlugin_RTL.h
@@ -1,0 +1,59 @@
+/*
+# SPDX-License-Identifier: GPL-3.0-or-later
+# TempestSDR Plugin Architecture:
+#  Copyright (c) 2014 Martin Marinov.
+*/
+#ifndef _TSDRPluginHeader
+#define _TSDRPluginHeader
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if _MSC_VER && !__INTEL_COMPILER
+  #define TSDRPLUGIN_API __declspec(dllexport)
+#elif defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TSDRPLUGIN_API __attribute__ ((dllexport))
+  #else
+    #define TSDRPLUGIN_API __declspec(dllexport)
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define TSDRPLUGIN_API __attribute__ ((visibility ("default")))
+  #else
+    #define TSDRPLUGIN_API
+  #endif
+#endif
+
+
+	#ifdef __cplusplus
+		#define EXTERNC extern "C"
+	#else
+		#define EXTERNC
+	#endif
+
+	#if !(defined(OS_WINDOWS) || defined(_WIN64)  || defined(_WIN32)  || defined(_MSC_VER) || defined(__stdcall))
+		#define __stdcall
+	#endif
+
+	#include <stdint.h>
+
+	typedef void(*tsdrplugin_readasync_function)(float *buf, uint64_t items_count, void *ctx, int64_t samples_dropped);
+
+	EXTERNC TSDRPLUGIN_API void __stdcall tsdrplugin_getName(char *);
+	EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_init(const char * params);
+	EXTERNC TSDRPLUGIN_API uint32_t __stdcall tsdrplugin_setsamplerate(uint32_t rate);
+	EXTERNC TSDRPLUGIN_API uint32_t __stdcall tsdrplugin_getsamplerate();
+	EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_setbasefreq(uint32_t freq);
+	EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_stop(void);
+	EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_setgain(float gain);
+	EXTERNC TSDRPLUGIN_API char* __stdcall tsdrplugin_getlasterrortext(void);
+	EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_readasync(tsdrplugin_readasync_function cb, void *ctx);
+	EXTERNC TSDRPLUGIN_API void __stdcall tsdrplugin_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TSDRPlugin_RawFile/makefile
+++ b/TSDRPlugin_RawFile/makefile
@@ -53,6 +53,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -72,6 +75,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM

--- a/TempestSDR/makefile
+++ b/TempestSDR/makefile
@@ -49,6 +49,9 @@ else ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),x86_64)
 		ARCHNAME = X64
 	endif
+	ifeq ($(shell uname -m),arm64)
+		ARCHNAME = ARM64
+	endif
 else
 
 	ifndef $(OSNAME)
@@ -68,6 +71,9 @@ else
 		endif
 		ifneq ($(filter %86,$(UNAME_M)),)
 			ARCHNAME = X86
+		endif
+		ifeq ($(UNAME_M),aarch64)
+			ARCHNAME = ARM64
 		endif
 		ifneq ($(filter arm%,$(UNAME_M)),)
 			ARCHNAME = ARM

--- a/makefile
+++ b/makefile
@@ -21,11 +21,19 @@ else
 	endif
 endif
 
+# Set to 1 to enable building TSDRPlugin_RTL, 0 to disable
+# Requires librtlsdr to be installed (e.g., via 'brew install librtlsdr' on macOS)
+BUILD_RTL_SDR ?= 0 
+# Disabled by default
+
 # Make all
 all :
 	@$(MAKE) -C TSDRPlugin_RawFile/ all JAVA_HOME=$(JAVA_HOME)
 ifeq ($(OSNAME),WINDOWS)
 	@$(MAKE) -C TSDRPlugin_ExtIO/ all
+endif
+ifeq ($(BUILD_RTL_SDR),1)
+	@$(MAKE) -C TSDRPlugin_RTL/ all JAVA_HOME=$(JAVA_HOME)
 endif
 	@$(MAKE) -C TempestSDR/ all
 	@$(MAKE) -C JavaGUI/ all
@@ -36,5 +44,6 @@ clean :
 	@$(MAKE) -C TSDRPlugin_Mirics/ clean
 	@$(MAKE) -C TSDRPlugin_ExtIO/ clean
 	@$(MAKE) -C TSDRPlugin_SDRPlay/ clean
+	@$(MAKE) -C TSDRPlugin_RTL/ clean
 	@$(MAKE) -C TempestSDR/ clean
 	@$(MAKE) -C JavaGUI/ clean


### PR DESCRIPTION
Adds librtlsdr based plugin for native rtl2832u SDR integration. 
Adds flag for enabling plugin build, disabled by default. 
Requires manual installation of the librtlsdr library itself, mentioned in plugin readme and in makefile.

Tested on MacOS Tahoe and RaspberryPiOS.

Made on top of previous pull request that adds arm64 support.